### PR TITLE
Option to provide high quality nanopore reads to flye with --nano-hq, default to --nano-raw.

### DIFF
--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -321,11 +321,11 @@ def main():
         '-z', '--longread-type', '--longread_type', '--long_read_type', '--long-read-type',
         help='Whether the sequencing platform and technology for the longreads. '
              '"rs" for PacBio RSII, "sq" for PacBio Sequel, "ccs" for PacBio CCS '
-             'reads and "ont" for Oxford Nanopore',
+             'reads, "ont" for Oxford Nanopore and "ont_hq" for Oxford Nanopore high quality reads (Guppy5+ or Q20)',
         dest='longread_type',
         nargs=1,
         default="ont",
-        choices=["ont", "rs", "sq", "ccs"],
+        choices=["ont","ont_hq", "rs", "sq", "ccs"],
     )
 
     ####################################################################

--- a/aviary/modules/assembly/assembly.smk
+++ b/aviary/modules/assembly/assembly.smk
@@ -408,7 +408,7 @@ rule spades_assembly:
         actualsize=$(stat -c%s data/short_reads.filt.fastq.gz);
         if [ $actualsize -ge $minimumsize ]
         then
-            if [ {params.long_read_type} = "ont" ]
+            if [ {params.long_read_type} = "ont" || {params.long_read_type} = "ont_hq" ]
             then
                 spades.py --memory {params.max_memory} --meta --nanopore {input.long_reads} --12 {input.fastq} \
                 -o data/spades_assembly -t {threads} -k 21,33,55,81,99,127 && \

--- a/aviary/modules/assembly/scripts/racon_polish.py
+++ b/aviary/modules/assembly/scripts/racon_polish.py
@@ -39,7 +39,7 @@ for rounds in range(snakemake.params.rounds):
             else:
                 subprocess.Popen("minimap2 -t %d -x sr %s %s > %s" % (snakemake.threads, reference, reads, paf),
                                  shell=True).wait()
-        elif snakemake.config["long_read_type"] == 'ont':
+        elif snakemake.config["long_read_type"] in ['ont', 'ont_hq']:
             subprocess.Popen("minimap2 -t %d -x map-ont %s %s > %s" % (snakemake.threads, reference, reads, paf), shell=True).wait()
         else:
             subprocess.Popen("minimap2 -t %d -x map-pb %s %s > %s" % (snakemake.threads, reference, reads, paf), shell=True).wait()

--- a/aviary/modules/assembly/scripts/run_flye.py
+++ b/aviary/modules/assembly/scripts/run_flye.py
@@ -3,6 +3,10 @@ import subprocess
 
 if snakemake.params.long_read_type == 'ont':
     subprocess.Popen(
+        "flye --nano-raw %s --meta -o data/flye -t %d -g %d" %
+        (snakemake.input.fastq, snakemake.threads, snakemake.params.genome_size), shell=True).wait()
+elif snakemake.params.long_read_type == 'ont_hq':
+    subprocess.Popen(
         "flye --nano-hq %s --meta -o data/flye -t %d -g %d" %
         (snakemake.input.fastq, snakemake.threads, snakemake.params.genome_size), shell=True).wait()
 elif snakemake.params.long_read_type == 'ccs':

--- a/aviary/modules/binning/scripts/get_abundances.py
+++ b/aviary/modules/binning/scripts/get_abundances.py
@@ -4,7 +4,7 @@ import sys
 
 
 if snakemake.config["long_reads"] != "none":
-    if snakemake.config["long_read_type"][0] == "ont":
+    if snakemake.config["long_read_type"][0] in ["ont", "ont_hq"]:
         subprocess.Popen("coverm genome -t %d -d bins/final_bins/ --single %s -p minimap2-ont --min-covered-fraction 0.0 -x fna %s > data/long_abundances.tsv" %
                          (snakemake.threads, " ".join(snakemake.config["long_reads"]),
                           '--bam-file-cache-directory data/binned_bams/ --discard-unmapped' if snakemake.config['strain_analysis'] is True else ''), shell=True).wait()

--- a/aviary/modules/binning/scripts/get_coverage.py
+++ b/aviary/modules/binning/scripts/get_coverage.py
@@ -2,7 +2,7 @@ import subprocess
 import os
 
 if snakemake.config["long_reads"] != "none" and not os.path.exists("data/long_cov.tsv"):
-    if snakemake.config["long_read_type"][0] == "ont":
+    if snakemake.config["long_read_type"][0] in ["ont", "ont_hq"]:
         subprocess.Popen("coverm contig -t %d -r %s --single %s -p minimap2-ont -m length trimmed_mean variance --bam-file-cache-directory data/binning_bams/ --discard-unmapped --min-read-percent-identity 0.7 > data/long_cov.tsv" %
                          (snakemake.threads, snakemake.input.fasta, " ".join(snakemake.config["long_reads"])), shell=True).wait()
     elif snakemake.config["long_read_type"][0] in ["rs", "sq", "ccs"]:


### PR DESCRIPTION
Assembling with `run_flye.py` currently defaults to ONT high-quality reads: Guppy5+ SUP or Q20. Going forward, this is likely what most people will be using, however it would be nice to support pre-Guppy5 for the time being.

Also see: https://github.com/fenderglass/Flye/issues/424
