### PR TITLE
test: Add short read recover.

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -40,6 +40,17 @@ class Tests(unittest.TestCase):
             self.assertTrue(os.path.isdir("{}/aviary_out".format(tmpdir)))
             self.assertTrue(os.path.isfile("{}/aviary_out/data/final_contigs.fasta".format(tmpdir)))
             self.assertTrue(os.path.islink("{}/aviary_out/assembly/final_contigs.fasta".format(tmpdir)))
+
+
+    def test_short_read_recovery(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = "aviary recover -o {}/aviary_out -1 {}/wgsim.1.fq.gz -2 {}/wgsim.2.fq.gz".format(tmpdir, data, data)
+            # print(cmd)
+            extern.run(cmd)
+            # TODO: Add more sanity checks.
+            self.assertTrue(os.path.isdir("{}/aviary_out".format(tmpdir)))
+            self.assertTrue(os.path.isfile("{}/aviary_out/data/final_contigs.fasta".format(tmpdir)))
+            self.assertTrue(os.path.islink("{}/aviary_out/assembly/final_contigs.fasta".format(tmpdir)))
         
 
 


### PR DESCRIPTION
This failed for me on the rosella step - any ideas @rhysnewell ?

This PR isn't finished, would need to check the bins that come out are good. MetaBAT made 2 bins so think the idea should work.

```
(aviary-dev5)cl5n007:20221019:~/git/aviary$ notify aviary recover -o /tmp/tmpsker9cbm/aviary_out -1 /mnt/hpccs01/home/woodcrob/git/aviary/test/data/wgsim.1.fq.gz -2 /mnt/hpccs01/home/woodcrob/git/aviary/test/data/wgsim.2.fq.gz
...
[2022-10-19T01:42:42Z INFO  rosella] rosella version 0.4.1                                                                                                                                                         
[2022-10-19T01:42:42Z INFO  rosella] Using min-covered-fraction 0%
[2022-10-19T01:42:42Z INFO  rosella] Using min-read-aligned-percent 0%                                                                                                                                             
[2022-10-19T01:42:42Z INFO  rosella::utils] Generating reference index                                                                                                                                             
[00:00:00] ████████████████████████████████████████     132/132     All contigs analyzed ✔ ETA: [0s]                                                                                                               
[00:00:09] ⠖ Calculating UMAP embeddings and clustering...    3/6                            
[2022-10-19T01:42:52Z ERROR bird_tool_utils::command] Error when running flight process. Exitstatus was : ExitStatus(unix_wait_status(256))
[2022-10-19T01:42:52Z ERROR bird_tool_utils::command] The STDERR was: "10/19/2022 11:42:43 AM INFO: Time - 11:42:43 19-10-2022\n10/19/2022 11:42:43 AM INFO: Command - /home/woodcrob/m/msingle/mess/112_targeted_r
ecovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/bin/flight bin --assembly assembly/final_contigs.fasta --input data/coverm.cov --kmer_frequencies data/rosella_bins/rosella_kmer_table.tsv --min_contig
_size 1500 --min_bin_size 200000 --n_neighbors 200 --output_directory data/rosella_bins/ --cores 8\nTraceback (most recent call last):\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_e
nvs/faebd0b100d97d20e14dda66ad5ad016_/bin/flight\", line 10, in <module>\n    sys.exit(main())\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/li
b/python3.9/site-packages/flight/flight.py\", line 449, in main\n    args.func(args)\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.
9/site-packages/flight/flight.py\", line 565, in bin\n    rosella = rosella_engine_constructor(args)\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad0
16_/lib/python3.9/site-packages/flight/flight.py\", line 536, in rosella_engine_constructor\n    from flight.rosella.rosella import Rosella\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/co
nda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.9/site-packages/flight/rosella/rosella.py\", line 48, in <module>\n    from flight.rosella.validating import Validator\n  File \"/home/woodcrob/m/msingle/me
ss/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.9/site-packages/flight/rosella/validating.py\", line 49, in <module>\n    from flight.rosella.clustering import Clusterer,
 iterative_clustering_static, kmeans_cluster\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.9/site-packages/flight/rosella/clusterin
g.py\", line 41, in <module>\n    import hdbscan\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.9/site-packages/hdbscan/__init__.py\
", line 1, in <module>\n    from .hdbscan_ import HDBSCAN, hdbscan\n  File \"/home/woodcrob/m/msingle/mess/112_targeted_recovery/avairy/conda_envs/faebd0b100d97d20e14dda66ad5ad016_/lib/python3.9/site-packages/hd
bscan/hdbscan_.py\", line 509, in <module>\n    memory=Memory(cachedir=None, verbose=0),\nTypeError: __init__() got an unexpected keyword argument 'cachedir'\n"                                                   
thread 'main' panicked at 'Failed to grab stdout from failed flight process', /home/conda/.cargo/registry/src/github.com-1ecc6299db9ec823/bird_tool_utils-0.3.0/src/command.rs:27:14
```