### PR TITLE
Fix checkm subprocess

### DIFF
--- a/aviary/modules/binning/scripts/run_checkm.py
+++ b/aviary/modules/binning/scripts/run_checkm.py
@@ -14,7 +14,8 @@ def checkm(checkm2_db, bin_folder, bin_ext, refinery_max_iterations, output_fold
         Path(output_file).touch()
     else:
         print(f"Using CheckM2 database {checkm2_db}/uniref100.KO.1.dmnd")
-        subprocess.run(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x {bin_ext} -o {output_folder} -t {threads} --force", shell=True)
+        os.environ["CHECKM2DB"] = f"{checkm2_db}/uniref100.KO.1.dmnd"
+        subprocess.run(f"checkm2 predict -i {bin_folder}/ -x {bin_ext} -o {output_folder} -t {threads} --force".split(), env=os.environ)
         shutil.copy(f"{output_folder}/quality_report.tsv", output_file)
 
 

--- a/aviary/modules/binning/scripts/run_checkm.py
+++ b/aviary/modules/binning/scripts/run_checkm.py
@@ -14,7 +14,7 @@ def checkm(checkm2_db, bin_folder, bin_ext, refinery_max_iterations, output_fold
         Path(output_file).touch()
     else:
         print(f"Using CheckM2 database {checkm2_db}/uniref100.KO.1.dmnd")
-        subprocess.run(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x {bin_ext} -o {output_folder} -t {threads} --force")
+        subprocess.run(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x {bin_ext} -o {output_folder} -t {threads} --force", shell=True)
         shutil.copy(f"{output_folder}/quality_report.tsv", output_file)
 
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -72,7 +72,7 @@ class Tests(unittest.TestCase):
                 f"-1 {data}/wgsim.1.fq.gz "
                 f"-2 {data}/wgsim.2.fq.gz "
                 f"--skip-binners concoct rosella vamb metabat maxbin "
-                f"--refinery-max-iterations 0 "
+                f"--refinery-max-iterations 1 "
                 f"--conda-prefix /home/aroneys/m/users/aroneys/.conda/envs "
                 f"-n 32 -t 32"
             )

--- a/test/test_run_checkm.py
+++ b/test/test_run_checkm.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import subprocess
 from pathlib import Path
 
-def create_output(_):
+def create_output(_, shell):
     os.makedirs("output_folder")
     Path(os.path.join("output_folder", "quality_report.tsv")).touch()
 
@@ -25,7 +25,7 @@ class Tests(unittest.TestCase):
 
                 checkm(checkm2_db, bin_folder, "fna", 1, "output_folder", "output_file", 1)
                 self.assertTrue(os.path.exists("output_file"))
-                mock_subprocess.assert_called_once_with(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x fna -o output_folder -t 1 --force")
+                mock_subprocess.assert_called_once_with(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x fna -o output_folder -t 1 --force", shell=True)
 
     def test_run_checkm_no_bins(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/test/test_run_checkm.py
+++ b/test/test_run_checkm.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import subprocess
 from pathlib import Path
 
-def create_output(_, shell):
+def create_output(_, env):
     os.makedirs("output_folder")
     Path(os.path.join("output_folder", "quality_report.tsv")).touch()
 
@@ -25,7 +25,8 @@ class Tests(unittest.TestCase):
 
                 checkm(checkm2_db, bin_folder, "fna", 1, "output_folder", "output_file", 1)
                 self.assertTrue(os.path.exists("output_file"))
-                mock_subprocess.assert_called_once_with(f"CHECKM2DB={checkm2_db}/uniref100.KO.1.dmnd checkm2 predict -i {bin_folder}/ -x fna -o output_folder -t 1 --force", shell=True)
+                os.environ["CHECKM2DB"] = f"{checkm2_db}/uniref100.KO.1.dmnd"
+                mock_subprocess.assert_called_once_with(f"checkm2 predict -i {bin_folder}/ -x fna -o output_folder -t 1 --force".split(), env=os.environ)
 
     def test_run_checkm_no_bins(self):
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
The command can fail with "No such file or directory" if the database path uses shell stuff.
Could open an injection vulnerability.