### PR TITLE
Implement skip abundances arg

### DIFF
--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -512,6 +512,14 @@ def main():
         # default=["maxbin2"]
     )
 
+    binning_group.add_argument(
+        '--skip-abundances', '--skip_abundances',
+        help='Skip CoverM post-binning abundance calculations.',
+        dest='skip_abundances',
+        default=False,
+        action="store_true",
+    )
+
     ####################################################################
     mag_group = argparse.ArgumentParser(formatter_class=CustomHelpFormatter,
                                         add_help=False)

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -636,7 +636,7 @@ rule finalise_stats:
     input:
         checkm1_done = "bins/checkm.out",
         checkm2_done = "bins/checkm2_output/quality_report.tsv",
-        coverage_file = "data/coverm_abundances.tsv",
+        coverage_file = "data/coverm_abundances.tsv" if not config["skip_abundances"] else [],
         gtdbtk_done = "data/gtdbtk/done"
     output:
         bin_stats = "bins/bin_info.tsv",
@@ -706,7 +706,7 @@ rule recover_mags:
     input:
         final_bins = "bins/bin_info.tsv",
         gtdbtk = "data/gtdbtk/done",
-        coverm = "data/coverm_abundances.tsv",
+        coverm = "data/coverm_abundances.tsv" if not config["skip_abundances"] else [],
         singlem = "data/singlem_out/singlem_appraisal.tsv"
     conda:
         "../../envs/coverm.yaml"
@@ -731,7 +731,7 @@ rule recover_mags:
 rule recover_mags_no_singlem:
     input:
         final_bins = "bins/bin_info.tsv",
-        coverm = "data/coverm_abundances.tsv",
+        coverm = "data/coverm_abundances.tsv" if not config["skip_abundances"] else [],
     conda:
         "../../envs/coverm.yaml"
     group: 'binning'

--- a/aviary/modules/binning/scripts/finalise_stats.py
+++ b/aviary/modules/binning/scripts/finalise_stats.py
@@ -62,7 +62,10 @@ def get_taxonomy(rename_columns="Bin Id"):
 
 
 if __name__ == "__main__":
-    coverage_file = pd.read_csv(snakemake.input.coverage_file, sep='\t')
+    try:
+        coverage_file = pd.read_csv(snakemake.input.coverage_file, sep='\t')
+    except ValueError:
+        coverage_file = pd.DataFrame(columns=["Genome"])
 
     # checkm file for all bins
     checkm1_output = pd.read_csv(snakemake.input.checkm1_done, sep='\t', comment="[")

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -405,7 +405,7 @@ class Processor:
 
             try:
                 logging.info("Executing: %s" % cmd)
-                subprocess.run(cmd.split())
+                subprocess.run(cmd.split(), check=True)
                 logging.info("Finished: %s" % workflow)
                 # logging.info("stderr: %s" % cmd_output)
             except subprocess.CalledProcessError as e:

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -109,6 +109,7 @@ class Processor:
             self.min_bin_size = args.min_bin_size
             self.semibin_model = args.semibin_model
             self.refinery_max_iterations = args.refinery_max_iterations
+            self.skip_abundances = args.skip_abundances
 
             self.skip_binners = []
             if args.skip_binners:
@@ -128,6 +129,7 @@ class Processor:
             self.semibin_model = 'global'
             self.refinery_max_iterations = 5
             self.skip_binners = ["none"]
+            self.skip_abundances = False
 
         try:
             self.assembly = args.assembly
@@ -309,6 +311,7 @@ class Processor:
         conf["gsa"] = self.gold_standard
         conf["gsa_mappings"] = self.gsa_mappings
         conf["skip_binners"] = self.skip_binners
+        conf["skip_abundances"] = self.skip_abundances
         conf["semibin_model"] = self.semibin_model
         conf["refinery_max_iterations"] = self.refinery_max_iterations
         conf["max_threads"] = int(self.threads)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -24,7 +24,6 @@
 import unittest
 import tempfile
 import os.path
-import extern
 import subprocess
 
 data = os.path.join(os.path.dirname(__file__), 'data')
@@ -41,7 +40,7 @@ class Tests(unittest.TestCase):
                 f"--conda-prefix {path_to_conda} "
                 f"-n 32 -t 32 --tmpdir {tmpdir} "
             )
-            extern.run(cmd)
+            subprocess.run(cmd, shell=True, check=True)
 
             self.assertTrue(os.path.isdir(f"{tmpdir}/aviary_out"))
             self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/data/final_contigs.fasta"))
@@ -59,7 +58,7 @@ class Tests(unittest.TestCase):
                 f"--conda-prefix {path_to_conda} "
                 f"-n 32 -t 32 --tmpdir {tmpdir} "
             )
-            extern.run(cmd)
+            subprocess.run(cmd, shell=True, check=True)
 
             self.assertTrue(os.path.isdir(f"{tmpdir}/aviary_out"))
             self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/data/final_contigs.fasta"))
@@ -76,7 +75,7 @@ class Tests(unittest.TestCase):
                 f"--conda-prefix {path_to_conda} "
                 f"-n 32 -t 32 --tmpdir {tmpdir} "
             )
-            extern.run(cmd)
+            subprocess.run(cmd, shell=True, check=True)
 
             self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/bins/bin_info.tsv"))
             self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/data/final_contigs.fasta"))
@@ -96,8 +95,27 @@ class Tests(unittest.TestCase):
                 f"--conda-prefix {path_to_conda} "
                 f"-n 32 -t 32 --tmpdir {tmpdir} "
             )
-            # output = subprocess.check_output(cmd, shell=True)
-            extern.run(cmd)
+            subprocess.run(cmd, shell=True, check=True)
+
+            self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/bins/bin_info.tsv"))
+            self.assertFalse(os.path.isfile(f"{tmpdir}/aviary_out/data/final_contigs.fasta"))
+
+
+    def test_short_read_recovery_skip_abundances(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = (
+                f"aviary recover "
+                f"--assembly {data}/assembly.fasta "
+                f"-o {tmpdir}/aviary_out "
+                f"-1 {data}/wgsim.1.fq.gz "
+                f"-2 {data}/wgsim.2.fq.gz "
+                f"--skip-abundances "
+                f"--skip-binners concoct rosella vamb metabat maxbin "
+                f"--refinery-max-iterations 1 "
+                f"--conda-prefix {path_to_conda} "
+                f"-n 32 -t 32 --tmpdir {tmpdir} "
+            )
+            subprocess.run(cmd, shell=True, check=True)
 
             self.assertTrue(os.path.isfile(f"{tmpdir}/aviary_out/bins/bin_info.tsv"))
             self.assertFalse(os.path.isfile(f"{tmpdir}/aviary_out/data/final_contigs.fasta"))

--- a/test/test_recover.py
+++ b/test/test_recover.py
@@ -225,10 +225,10 @@ class Tests(unittest.TestCase):
             self.assertTrue("checkm2" in output)
             self.assertTrue("gtdbtk" in output)
             self.assertTrue("get_abundances" not in output)
-            self.assertTrue("singlem_pipe_reads" not in output)
-            self.assertTrue("singlem_appraise" not in output)
+            self.assertTrue("singlem_pipe_reads" in output)
+            self.assertTrue("singlem_appraise" in output)
             self.assertTrue("finalise_stats" in output)
-            self.assertTrue("recover_mags_no_singlem" in output)
+            self.assertTrue("recover_mags" in output)
 
             # Unnecessary
             self.assertTrue("complete_assembly_with_qc" not in output)

--- a/test/test_recover.py
+++ b/test/test_recover.py
@@ -178,6 +178,61 @@ class Tests(unittest.TestCase):
             # Unnecessary
             self.assertTrue("complete_assembly_with_qc" not in output)
 
+    def test_recover_no_abundances(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = (
+                f"GTDBTK_DATA_PATH=. "
+                f"CHECKM2DB=. "
+                f"EGGNOG_DATA_DIR=. "
+                f"aviary recover "
+                f"--skip-abundances "
+                f"--assembly {ASSEMBLY} "
+                f"-1 {FORWARD_READS} "
+                f"-2 {REVERSE_READS} "
+                f"--output {tmpdir}/test "
+                f"--conda-prefix {path_to_conda} "
+                f"--dryrun --tmpdir {tmpdir} "
+                f"--snakemake-cmds \" --quiet\" "
+            )
+            output = extern.run(cmd)
+
+            # Binners
+            self.assertTrue("prepare_binning_files" in output)
+            self.assertTrue("get_bam_indices" in output)
+            self.assertTrue("metabat_sens" in output)
+            self.assertTrue("metabat_spec" in output)
+            self.assertTrue("metabat_ssens" in output)
+            self.assertTrue("metabat_sspec" in output)
+            self.assertTrue("metabat2" in output)
+            self.assertTrue("maxbin2" in output)
+            self.assertTrue("rosella" in output)
+            self.assertTrue("semibin" in output)
+            self.assertTrue("vamb" in output)
+            self.assertTrue("concoct" in output)
+            self.assertTrue("das_tool" in output)
+
+            # Refinery
+            self.assertTrue("checkm_metabat2" in output)
+            self.assertTrue("refine_metabat2" in output)
+            self.assertTrue("checkm_rosella" in output)
+            self.assertTrue("refine_rosella" in output)
+            self.assertTrue("checkm_semibin" in output)
+            self.assertTrue("refine_semibin" in output)
+            self.assertTrue("checkm_das_tool" in output)
+            self.assertTrue("refine_dastool" in output)
+
+            # Extras
+            self.assertTrue("checkm2" in output)
+            self.assertTrue("gtdbtk" in output)
+            self.assertTrue("get_abundances" not in output)
+            self.assertTrue("singlem_pipe_reads" not in output)
+            self.assertTrue("singlem_appraise" not in output)
+            self.assertTrue("finalise_stats" in output)
+            self.assertTrue("recover_mags_no_singlem" in output)
+
+            # Unnecessary
+            self.assertTrue("complete_assembly_with_qc" not in output)
+
     def test_recover_config(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cmd = (


### PR DESCRIPTION
Add argument to recover to skip CoverM abundances post-binning.
Last unskippable rule that isn't necessary for large-scale binning efforts.

- [x] Tested in dryrun
- [x] Tested manually in test_integration.py
- [x] Tested manually with real samples