### PR TITLE
Remove upper snakemake bound

### DIFF
--- a/aviary.yml
+++ b/aviary.yml
@@ -4,7 +4,7 @@ channels:
   - anaconda
 dependencies:
   - python>=3.8
-  - snakemake>=6.0.5
+  - snakemake>=6.0.5,<=7.32.3
   - ruamel.yaml>=0.15.99 # needs to be explicit
   - numpy
   - pandas

--- a/aviary.yml
+++ b/aviary.yml
@@ -4,7 +4,7 @@ channels:
   - anaconda
 dependencies:
   - python>=3.8
-  - snakemake>=6.0.5,<=7.17
+  - snakemake>=6.0.5
   - ruamel.yaml>=0.15.99 # needs to be explicit
   - numpy
   - pandas

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -73,7 +73,6 @@ class Tests(unittest.TestCase):
         self.assertTrue(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
         self.assertTrue(os.path.islink(f"{output_dir}/aviary_out/assembly/final_contigs.fasta"))
 
-
     def test_short_read_recovery(self):
         output_dir = os.path.join("example", "test_short_read_recovery")
         self.setup_output_dir(output_dir)
@@ -115,7 +114,6 @@ class Tests(unittest.TestCase):
         self.assertTrue(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
         self.assertTrue(os.path.islink(f"{output_dir}/aviary_out/assembly/final_contigs.fasta"))
 
-
     def test_short_read_recovery_fast(self):
         output_dir = os.path.join("example", "test_short_read_recovery_fast")
         self.setup_output_dir(output_dir)
@@ -140,7 +138,6 @@ class Tests(unittest.TestCase):
         self.assertEqual(num_lines, 3)
 
         self.assertFalse(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
-
 
     def test_short_read_recovery_queue_submission(self):
         output_dir = os.path.join("example", "test_short_read_recovery_queue_submission")


### PR DESCRIPTION
I think this was set due to an bug in a snakemake version that has since been fixed. Current snakemake version is v7.32.3.
Though perhaps we should fix all the software versions to a known working set?

Integration tests:
- [x] test_short_read_assembly
- [x] test_long_read_assembly
- [x] test_short_read_recovery
- [x] test_long_read_recovery
- [x] test_short_read_recovery_fast
- [x] test_short_read_recovery_queue_submission