### PR TITLE
Make long read qc temp

### DIFF
--- a/aviary/modules/quality_control/qc.smk
+++ b/aviary/modules/quality_control/qc.smk
@@ -15,7 +15,7 @@ rule link_reads:
     params:
         coassemble = config["coassemble"]
     output:
-        "data/long_reads.fastq.gz"
+        temp("data/long_reads.fastq.gz")
     threads:
         config['max_threads']
     run:
@@ -37,7 +37,7 @@ rule filtlong_no_reference:
     input:
         long = config['long_reads']
     output:
-        long = "data/long_reads.fastq.gz",
+        long = temp("data/long_reads.fastq.gz"),
     params:
         min_length = config['min_long_read_length'],
         keep_percent = config['keep_percent'],


### PR DESCRIPTION
The cost to storage is not worth having an extra copy of your nanopore reads sitting around just to save time during the QC stage. If users are unaware that they can delete this file then we'll quickly be filling up peoples servers with junk.
