### PR TITLE
megahit: Specify -m in bytes.

### DIFF
--- a/aviary/modules/assembly/scripts/assemble_short_reads.py
+++ b/aviary/modules/assembly/scripts/assemble_short_reads.py
@@ -85,8 +85,8 @@ def assemble_short_reads(
 
     # Run chosen assembler
     if use_megahit:
-
-        command = f"megahit {read_string} -t {threads} -m {max_memory} -o data/megahit_assembly --tmp-dir {tmp_dir}"
+        max_memory_in_bytes = max_memory * 1024*1024*1024
+        command = f"megahit {read_string} -t {threads} -m {max_memory_in_bytes} -o data/megahit_assembly --tmp-dir {tmp_dir}"
 
         with open(log, 'a') as logf:
             logf.write(f"Queueing command {command}\n")


### PR DESCRIPTION
Saw this in my logs otherwise

```
Memory available in less than memory required (500 < 75256048790), still trying to perform sorting
```
