### PR TITLE
Update annotation.smkwith new GTDB DB URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ use the the `aviary configure` module to update the environment variables used b
 
 These environment variables can also be configured manually, just set the following variables in your `.bashrc` file:
 ```
-export GTDBTK_DATA_PATH=/path/to/gtdb/gtdb_release207/db/ # https://gtdb.ecogenomic.org/downloads
+export GTDBTK_DATA_PATH=/path/to/gtdb/gtdb_release220/db/ # https://gtdb.ecogenomic.org/downloads
 export EGGNOG_DATA_DIR=/path/to/eggnog-mapper/2.1.8/ # https://github.com/eggnogdb/eggnog-mapper/wiki/eggNOG-mapper-v2.1.5-to-v2.1.8#setup
 export SINGLEM_METAPACKAGE_PATH=/path/to/singlem_metapackage.smpkg/
 export CHECKM2DB=/path/to/checkm2db/

--- a/aviary.yml
+++ b/aviary.yml
@@ -4,7 +4,7 @@ channels:
   - anaconda
 dependencies:
   - python >=3.8,<=3.11
-  - snakemake >=7.0.0,<=7.32.3
+  - snakemake =8.12.0
   - ruamel.yaml >=0.15.99 # needs to be explicit
   - numpy
   - pandas

--- a/aviary.yml
+++ b/aviary.yml
@@ -4,7 +4,7 @@ channels:
   - anaconda
 dependencies:
   - python >=3.8,<=3.11
-  - snakemake =8.12.0
+  - snakemake >=7.0.0,<=7.32.3
   - ruamel.yaml >=0.15.99 # needs to be explicit
   - numpy
   - pandas

--- a/aviary/envs/gtdbtk.yaml
+++ b/aviary/envs/gtdbtk.yaml
@@ -2,5 +2,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - gtdbtk = 2.3
+  - gtdbtk = 2.4.0
   - fastani

--- a/aviary/modules/annotation/annotation.smk
+++ b/aviary/modules/annotation/annotation.smk
@@ -74,7 +74,7 @@ rule download_gtdb:
         'GTDBTK_DATA_PATH={params.gtdbtk_folder}; '
         'mkdir -p {params.gtdbtk_folder}; '
         # Configuration
-        'DB_URL="https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_data.tar.gz"; '
+        'DB_URL="https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_package/full_package/gtdbtk_data.tar.gz"; '
         'TARGET_TAR_NAME="gtdbtk_data.tar.gz"; '
 
         # Script variables (no need to configure)

--- a/aviary/modules/annotation/annotation.smk
+++ b/aviary/modules/annotation/annotation.smk
@@ -74,7 +74,7 @@ rule download_gtdb:
         'GTDBTK_DATA_PATH={params.gtdbtk_folder}; '
         'mkdir -p {params.gtdbtk_folder}; '
         # Configuration
-        'DB_URL="https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_package/full_package/gtdbtk_data.tar.gz"; '
+        'DB_URL="https://data.gtdb.ecogenomic.org/releases/release220/220.0/auxillary_files/gtdbtk_package/full_package/gtdbtk_r220_data.tar.gz"; '
         'TARGET_TAR_NAME="gtdbtk_data.tar.gz"; '
 
         # Script variables (no need to configure)


### PR DESCRIPTION
This gives a 404 error (as of 2024-06-01):
https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_data.tar.gz

This seems to be the same file:
https://data.gtdb.ecogenomic.org/releases/latest/auxillary_files/gtdbtk_package/full_package/gtdbtk_data.tar.gz