### PR TITLE
Increase base vamb runtime to 48h

### DIFF
--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -178,7 +178,7 @@ rule vamb:
         config["max_threads"]
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
-        runtime = lambda wildcards, attempt: 24*60*attempt,
+        runtime = lambda wildcards, attempt: 48*60*attempt,
         gpus = 1 if config["request_gpu"] else 0
     output:
         "data/vamb_bins/done"


### PR DESCRIPTION
While we are making some changes, VAMB nearly always takes longer than 24h to run with 16 threads.