### PR TITLE
Add COMEbin as another optional binner

### DIFF
--- a/aviary.yml
+++ b/aviary.yml
@@ -14,3 +14,4 @@ dependencies:
   - parallel
   - bbmap
   - extern # for tests
+  - pyopenssl>22.1.0 # see https://github.com/pyca/cryptography/issues/7959#issuecomment-1368711852

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -594,11 +594,11 @@ def main():
     binning_group.add_argument(
         '--skip-binners', '--skip_binners', '--skip_binner', '--skip-binner',
         help='Optional list of binning algorithms to skip. Can be any combination of: \n'
-             'rosella, semibin, metabat1, metabat2, metabat, vamb \n'
+             'rosella, semibin, metabat1, metabat2, metabat, vamb, comebin \n'
              'N.B. specifying "metabat" will skip both MetaBAT1 and MetaBAT2. \n',
         dest='skip_binners',
         nargs='*',
-        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb"]
+        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb", "comebin"]
     )
 
     binning_group.add_argument(

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -583,22 +583,22 @@ def main():
     binning_group.add_argument(
         '--extra-binners', '--extra_binners', '--extra-binner', '--extra_binner',
         help='Optional list of extra binning algorithms to run. Can be any combination of: \n'
-             'maxbin, maxbin2, concoct \n'
+             'maxbin, maxbin2, concoct, comebin \n'
              'These binners are skipped by default as they can have long runtimes \n'
              'N.B. specifying "maxbin" and "maxbin2" are equivalent \n',
         dest='extra_binners',
         nargs='*',
-        choices=["maxbin", "maxbin2", "concoct"]
+        choices=["maxbin", "maxbin2", "concoct", "comebin"]
     )
 
     binning_group.add_argument(
         '--skip-binners', '--skip_binners', '--skip_binner', '--skip-binner',
         help='Optional list of binning algorithms to skip. Can be any combination of: \n'
-             'rosella, semibin, metabat1, metabat2, metabat, vamb, comebin \n'
+             'rosella, semibin, metabat1, metabat2, metabat, vamb \n'
              'N.B. specifying "metabat" will skip both MetaBAT1 and MetaBAT2. \n',
         dest='skip_binners',
         nargs='*',
-        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb", "comebin"]
+        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb"]
     )
 
     binning_group.add_argument(

--- a/aviary/modules/binning/envs/comebin.yaml
+++ b/aviary/modules/binning/envs/comebin.yaml
@@ -1,0 +1,9 @@
+channels:
+  - pytorch
+  - nvidia
+  - conda-forge
+  - bioconda
+dependencies:
+  - comebin=1.0.*
+  - pytorch
+  - pytorch-cuda=11.8

--- a/aviary/modules/binning/scripts/das_tool.py
+++ b/aviary/modules/binning/scripts/das_tool.py
@@ -8,10 +8,13 @@ if __name__ == '__main__':
     unrefined_binners_to_use = [
         ('concoct', 'fa'),
         ('maxbin2', 'fasta'),
-        ('vamb', 'fna')]
+        ('vamb', 'fna'),
+        ('comebin', 'fa'),
+        ]
     refined_binners_to_use = [
         ('rosella', 'fna'),
-        ('semibin', 'fna')]
+        ('semibin', 'fna'),
+        ]
 
     # N.B. specifying "metabat" will skip both MetaBAT1 and MetaBAT2.
     metabats = ['metabat_sspec', 'metabat_ssens', 'metabat_sens', 'metabat_spec']
@@ -19,7 +22,12 @@ if __name__ == '__main__':
     binners = []
     for (binner, extension) in unrefined_binners_to_use:
         if binner not in snakemake.config['skip_binners']:
-            extra = 'bins/' if binner == 'vamb' else ''
+            extra = ''
+            if binner == 'vamb':
+                extra = 'bins/'
+            elif binner == 'comebin':
+                extra = 'comebin_res/comebin_res_bins/'
+
             binners.append((f'{binner}_bins/'+extra, extension, f'data/{binner}_bins.tsv'))
 
     for (binner, extension) in refined_binners_to_use:

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -124,7 +124,7 @@ class Processor:
                 self.skip_singlem = True
             self.binning_only = args.binning_only
 
-            self.skip_binners = ["maxbin2", "concoct"]
+            self.skip_binners = ["maxbin2", "concoct", "comebin"]
             if args.extra_binners:
                 for binner in args.extra_binners:
                     binner = binner.lower()   
@@ -132,6 +132,8 @@ class Processor:
                         self.skip_binners.remove("maxbin2")
                     elif binner == "concoct":
                         self.skip_binners.remove("concoct")
+                    elif binner == "comebin":
+                        self.skip_binners.remove("comebin")
                     else:
                         logging.warning(f"Unknown extra binner {binner} specified. Skipping...")
 

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -211,6 +211,7 @@ class Tests(unittest.TestCase):
             f"-2 {data}/wgsim.2.fq.gz "
             f"--binning-only "
             f"--skip-binners rosella semibin metabat vamb "
+            f"--extra-binners comebin "
             f"--skip-qc "
             f"--refinery-max-iterations 0 "
             f"--conda-prefix {path_to_conda} "

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -191,6 +191,41 @@ class Tests(unittest.TestCase):
 
         self.assertFalse(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
 
+    def test_short_read_recovery_comebin(self):
+        output_dir = os.path.join("example", "test_short_read_recovery_comebin")
+        self.setup_output_dir(output_dir)
+
+        # Create inflated assembly file
+        cmd = f"cat {data}/assembly.fasta > {output_dir}/assembly.fasta"
+        multiplier = 100
+        for i in range(multiplier):
+            cmd += f" && awk '/^>/ {{print $0 \"{i}\"}} !/^>/ {{print $0}}' {data}/assembly.fasta >> {output_dir}/assembly.fasta"
+
+        subprocess.run(cmd, shell=True, check=True)
+
+        cmd = (
+            f"aviary recover "
+            f"--assembly {output_dir}/assembly.fasta "
+            f"-o {output_dir}/aviary_out "
+            f"-1 {data}/wgsim.1.fq.gz "
+            f"-2 {data}/wgsim.2.fq.gz "
+            f"--binning-only "
+            f"--skip-binners rosella semibin metabat vamb "
+            f"--skip-qc "
+            f"--refinery-max-iterations 0 "
+            f"--conda-prefix {path_to_conda} "
+            f"-n 32 -t 32 "
+        )
+        subprocess.run(cmd, shell=True, check=True)
+
+        bin_info_path = f"{output_dir}/aviary_out/bins/bin_info.tsv"
+        self.assertTrue(os.path.isfile(bin_info_path))
+        with open(bin_info_path) as f:
+            num_lines = sum(1 for _ in f)
+        self.assertTrue(num_lines > 2)
+
+        self.assertFalse(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
+
     @unittest.skip("Skipping test due to queue submission")
     def test_short_read_recovery_queue_submission(self):
         output_dir = os.path.join("example", "test_short_read_recovery_queue_submission")


### PR DESCRIPTION
Test passes, but it adds a bunch of tmp files at the position of the input assembly:

```bash
ls example/test_short_read_recovery_comebin/assembly.fasta*
example/test_short_read_recovery_comebin/assembly.fasta                                            example/test_short_read_recovery_comebin/assembly.fasta.frag.faa
example/test_short_read_recovery_comebin/assembly.fasta.bacar_marker.2quarter_lencutoff_1001.seed  example/test_short_read_recovery_comebin/assembly.fasta.frag.ffn
example/test_short_read_recovery_comebin/assembly.fasta.bacar_marker.hmmout                        example/test_short_read_recovery_comebin/assembly.fasta.frag.gff
example/test_short_read_recovery_comebin/assembly.fasta.bacar_marker.hmmout.err                    example/test_short_read_recovery_comebin/assembly.fasta.frag.out
example/test_short_read_recovery_comebin/assembly.fasta.bacar_marker.hmmout.out                    example/test_short_read_recovery_comebin/assembly.fasta_lengths.txt
example/test_short_read_recovery_comebin/assembly.fasta.frag.err
```

I guess we could symlink the assembly into the comebin output folder to contain the mess.