### PR TITLE
Pep 625 fix

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -34,6 +34,7 @@ jobs:
     - name: Build a binary wheel and a source tarball
       run: >-
         python setup.py sdist
+        mv dist/aviary-genome-*.tar.gz dist/aviary_genome-${{ env.RELEASE_VERSION }}.tar.gz
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
@@ -49,4 +50,4 @@ jobs:
         automatic_release_tag: "${{ env.RELEASE_VERSION }}"
         title: "${{ env.RELEASE_VERSION }}"
         files: |
-          dist/aviary-genome-*.tar.gz
+          dist/aviary_genome-${{ env.RELEASE_VERSION }}.tar.gz


### PR DESCRIPTION
This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'aviary-genome'.

In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'aviary-genome-0.11.0.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'aviary_genome'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames.

If you have questions, you can email [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI administrators.