### PR TITLE
checkm2: Update to 1.1.0.

### DIFF
--- a/aviary/envs/checkm2.yaml
+++ b/aviary/envs/checkm2.yaml
@@ -3,21 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python >=3.7, <3.9
-  - scikit-learn =0.23.2
-  - h5py =2.10.0
-  - numpy =1.19.2
-  - diamond =2.0.4
-  - tensorflow >= 2.2.0, <2.6.0
-  - lightgbm =3.2.1
-  - pandas =1.4.0
-  - scipy =1.8.0
-  - prodigal =2.6.3
-  - setuptools
-  - requests
-  - packaging
-  - tqdm
-  - pip
-  - git
-  - pip:
-      - "git+https://github.com/chklovski/CheckM2.git#egg=checkm2"
+  - checkm2==1.1.0


### PR DESCRIPTION
Unclear about how to handle DB update, but it seems to work with the old DB anyway.

Actually might need to check the download instructions to make sure they work before merging this.