### PR TITLE
Sembin sample counting bug

### DIFF
--- a/aviary/envs/checkm2.yaml
+++ b/aviary/envs/checkm2.yaml
@@ -3,21 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python >=3.7, <3.9
-  - scikit-learn =0.23.2
-  - h5py =2.10.0
-  - numpy =1.19.2
-  - diamond =2.0.4
-  - tensorflow >= 2.2.0, <2.6.0
-  - lightgbm =3.2.1
-  - pandas =1.4.0
-  - scipy =1.8.0
-  - prodigal =2.6.3
-  - setuptools
-  - requests
-  - packaging
-  - tqdm
-  - pip
-  - git
-  - pip:
-      - "git+https://github.com/chklovski/CheckM2.git#egg=checkm2"
+  - checkm2==1.1.0

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -469,6 +469,16 @@ rule rosella:
         "--min-contig-size {params.min_contig_size} --min-bin-size {params.min_bin_size} --n-neighbors 100 > {log} 2>&1 && "
         "touch {output.done} || touch {output.done}"
 
+def get_num_samples():
+    """
+    Get the number of samples in the config
+    """
+    num_samples = 0
+    if config["long_reads"] != "none":
+        num_samples += len(config["long_reads"])
+    if config["short_reads_1"] != "none":
+        num_samples += len(config["short_reads_1"])
+    return num_samples
 
 rule semibin:
     input:
@@ -476,7 +486,7 @@ rule semibin:
         bams_indexed = ancient("data/binning_bams/done")
     params:
         # Can't use premade model with multiple samples, so disregard if provided
-        semibin_model = f"--environment {config['semibin_model']} " if len(config["short_reads_1"]) == 1 else ""
+        semibin_model = f"--environment {config['semibin_model']} " if get_num_samples() == 1 else ""
     output:
         done = "data/semibin_bins/done"
     threads:


### PR DESCRIPTION
When there was a short read and a long read (or multiple long reads), the pre model would be used, which silently crashed semibin.