### PR TITLE
Remove mamba

### DIFF
--- a/aviary.yml
+++ b/aviary.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy
   - pandas
   - biopython
-  - mamba >=0.8.2
+  - conda =25.1.1
   - pigz =2.6
   - parallel
   - bbmap

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -250,15 +250,6 @@ def main():
     )
 
     base_group.add_argument(
-        '--conda-frontend', '--conda_frontend',
-        help='Which conda frontend to use, mamba is faster but harder to debug. Switch this to conda \n'
-             'If experiencing problems installing environments',
-        dest='conda_frontend',
-        default="mamba",
-        choices=["conda", "mamba"],
-    )
-
-    base_group.add_argument(
         '--clean',
         help='Clean up all temporary files. This will remove most BAM files and any FASTQ files \n'
              'generated from read filtering. Setting this to False is the equivalent of the --notemp \n'
@@ -1294,7 +1285,6 @@ def main():
                                local_cores=int(args.local_cores),
                                dryrun=args.dryrun,
                                clean=args.clean,
-                               conda_frontend=args.conda_frontend,
                                snakemake_args=args.cmds,
                                rerun_triggers=args.rerun_triggers,
                                profile=args.snakemake_profile,

--- a/aviary/envs/checkm2.yaml
+++ b/aviary/envs/checkm2.yaml
@@ -3,21 +3,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - python >=3.7, <3.9
-  - scikit-learn =0.23.2
-  - h5py =2.10.0
-  - numpy =1.19.2
-  - diamond =2.0.4
-  - tensorflow >= 2.2.0, <2.6.0
-  - lightgbm =3.2.1
-  - pandas =1.4.0
-  - scipy =1.8.0
-  - prodigal =2.6.3
-  - setuptools
-  - requests
-  - packaging
-  - tqdm
-  - pip
-  - git
-  - pip:
-      - "git+https://github.com/chklovski/CheckM2.git#egg=checkm2"
+  - checkm2==1.1.0

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -469,6 +469,16 @@ rule rosella:
         "--min-contig-size {params.min_contig_size} --min-bin-size {params.min_bin_size} --n-neighbors 100 > {log} 2>&1 && "
         "touch {output.done} || touch {output.done}"
 
+def get_num_samples():
+    """
+    Get the number of samples in the config
+    """
+    num_samples = 0
+    if config["long_reads"] != "none":
+        num_samples += len(config["long_reads"])
+    if config["short_reads_1"] != "none":
+        num_samples += len(config["short_reads_1"])
+    return num_samples
 
 rule semibin:
     input:
@@ -476,7 +486,7 @@ rule semibin:
         bams_indexed = ancient("data/binning_bams/done")
     params:
         # Can't use premade model with multiple samples, so disregard if provided
-        semibin_model = f"--environment {config['semibin_model']} " if len(config["short_reads_1"]) == 1 else ""
+        semibin_model = f"--environment {config['semibin_model']} " if get_num_samples() == 1 else ""
     output:
         done = "data/semibin_bins/done"
     threads:

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -453,7 +453,7 @@ class Processor:
         load_configfile(self.config)
 
     def run_workflow(self, cores=16, local_cores=None, profile=None, cluster_retries=None,
-                     dryrun=False, clean=True, conda_frontend="mamba",
+                     dryrun=False, clean=True,
                      snakemake_args="", write_to_script=None, rerun_triggers=None):
         """
         Runs the aviary pipeline
@@ -493,7 +493,7 @@ class Processor:
                 args=snakemake_args,
                 target_rule=workflow if workflow != "None" else "",
                 conda_prefix="--conda-prefix " + self.conda_prefix,
-                conda_frontend="--conda-frontend " + conda_frontend,
+                conda_frontend="--conda-frontend " + "conda",
                 resources=f"--resources mem_mb={int(self.max_memory)*1024} {self.resources}" if not dryrun else ""
             )
 
@@ -612,7 +612,6 @@ def process_batch(args, prefix):
         processor.run_workflow(cores=int(new_args.n_cores),
                                dryrun=new_args.dryrun,
                                clean=new_args.clean,
-                               conda_frontend=new_args.conda_frontend,
                                snakemake_args=new_args.cmds,
                                rerun_triggers=new_args.rerun_triggers,
                                profile=new_args.snakemake_profile,
@@ -636,7 +635,6 @@ def process_batch(args, prefix):
             processor.run_workflow(cores=int(args.n_cores),
                                    dryrun=args.dryrun,
                                    clean=args.clean,
-                                   conda_frontend=args.conda_frontend,
                                    snakemake_args=args.cmds,
                                    rerun_triggers=args.rerun_triggers,
                                    profile=args.snakemake_profile,


### PR DESCRIPTION
Currently on top of #256 and #257, too lazy to be independent but could later if required.

This is backwards incompatible because the command line option is removed. We could keep it but ignore it and always use conda instead of the (now deprecated) mamba?