### PR TITLE
Split get coverage into separate jobs when many samples

### DIFF
--- a/aviary/__init__.py
+++ b/aviary/__init__.py
@@ -23,3 +23,5 @@ MEDAKA_MODELS = [
     "r941_prom_snp_g360", "r941_prom_sup_g507", "r941_prom_sup_snp_g507", "r941_prom_sup_variant_g507", "r941_prom_variant_g303",
     "r941_prom_variant_g322", "r941_prom_variant_g360", "r941_sup_plant_g610", "r941_sup_plant_variant_g610"
 ]
+COVERAGE_JOB_STRATEGIES = ["default", "always", "never"]
+COVERAGE_JOB_CUTOFF = 10

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -563,8 +563,10 @@ def main():
 
     binning_group.add_argument(
         '--coverage-job-strategy', '--coverage_job_strategy',
-        help=f'Strategy for splitting samples when calculating coverage for binning. Choices include: \n'
-             f'"default" for only splitting into separate jobs when more than {COVERAGE_JOB_CUTOFF} samples are provided, "never" and "always".',
+        help=f'When large numbers of samples are used for co-binning, it can be more computationally scalable to \n'
+             f'calculate coverage across multiple jobs. By default, if there are more than {COVERAGE_JOB_CUTOFF} samples,\n'
+             f'Aviary will calculate coverage in groups of N, where N is determined by `--coverage-samples-per-job`.\n'
+             f'Can be one of: "default" (as above), "never" and "always".',
         dest='coverage_job_strategy',
         choices=COVERAGE_JOB_STRATEGIES,
         default=COVERAGE_JOB_STRATEGIES[0],

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -19,7 +19,7 @@
 ###############################################################################
 import aviary.config.config as Config
 from aviary.modules.processor import Processor, process_batch
-from .__init__ import __version__, MEDAKA_MODELS, LONG_READ_TYPES
+from .__init__ import __version__, MEDAKA_MODELS, LONG_READ_TYPES, COVERAGE_JOB_STRATEGIES, COVERAGE_JOB_CUTOFF
 __author__ = "Rhys Newell"
 __copyright__ = "Copyright 2022"
 __credits__ = ["Rhys Newell"]
@@ -559,6 +559,23 @@ def main():
         help='Minimum bin size in base pairs for a MAG',
         dest='min_bin_size',
         default=200000
+    )
+
+    binning_group.add_argument(
+        '--coverage-job-strategy', '--coverage_job_strategy',
+        help=f'Strategy for splitting samples when calculating coverage for binning. Choices include: \n'
+             f'"default" for only splitting into separate jobs when more than {COVERAGE_JOB_CUTOFF} samples are provided, "never" and "always".',
+        dest='coverage_job_strategy',
+        choices=COVERAGE_JOB_STRATEGIES,
+        default=COVERAGE_JOB_STRATEGIES[0],
+    )
+
+    binning_group.add_argument(
+        '--coverage-samples-per-job', '--coverage_samples_per_job',
+        help='',
+        dest='coverage_samples_per_job',
+        type=int,
+        default=5,
     )
 
     binning_group.add_argument(

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -47,6 +47,17 @@ import os
 import sys
 import glob
 
+def get_num_samples():
+    """
+    Get the number of samples in the config
+    """
+    num_samples = 0
+    if config["long_reads"] != "none":
+        num_samples += len(config["long_reads"])
+    if config["short_reads_1"] != "none":
+        num_samples += len(config["short_reads_1"])
+    return num_samples
+
 rule prepare_binning_files:
     input:
         input_fasta = config["fasta"]
@@ -54,7 +65,11 @@ rule prepare_binning_files:
         maxbin_coverage = "data/maxbin.cov.list",
         metabat_coverage = "data/coverm.cov"
     params:
-        tmpdir = config['tmpdir']
+        tmpdir = config['tmpdir'],
+        long_reads = snakemake.config["long_reads"],
+        long_read_type = snakemake.config["long_read_type"][0],
+        short_reads_1 = snakemake.config["short_reads_1"],
+        short_reads_2 = snakemake.config["short_reads_2"],
     conda:
         "../../envs/coverm.yaml"
     threads:
@@ -468,17 +483,6 @@ rule rosella:
         "rosella recover -r {input.fasta} -C {input.coverage} -t {threads} -o data/rosella_bins "
         "--min-contig-size {params.min_contig_size} --min-bin-size {params.min_bin_size} --n-neighbors 100 > {log} 2>&1 && "
         "touch {output.done} || touch {output.done}"
-
-def get_num_samples():
-    """
-    Get the number of samples in the config
-    """
-    num_samples = 0
-    if config["long_reads"] != "none":
-        num_samples += len(config["long_reads"])
-    if config["short_reads_1"] != "none":
-        num_samples += len(config["short_reads_1"])
-    return num_samples
 
 rule semibin:
     input:

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -66,10 +66,12 @@ rule prepare_binning_files:
         metabat_coverage = "data/coverm.cov"
     params:
         tmpdir = config['tmpdir'],
-        long_reads = snakemake.config["long_reads"],
-        long_read_type = snakemake.config["long_read_type"][0],
-        short_reads_1 = snakemake.config["short_reads_1"],
-        short_reads_2 = snakemake.config["short_reads_2"],
+        long_reads = config["long_reads"],
+        long_read_type = config["long_read_type"][0],
+        short_reads_1 = config["short_reads_1"],
+        short_reads_2 = config["short_reads_2"],
+        bam_cache = "data/binning_bams/",
+        working_dir = "data/binning_cov/",
     conda:
         "../../envs/coverm.yaml"
     threads:

--- a/aviary/modules/binning/scripts/get_coverage.py
+++ b/aviary/modules/binning/scripts/get_coverage.py
@@ -170,10 +170,10 @@ def get_coverage(
 
 
 if __name__ == '__main__':
-    long_reads = snakemake.config["long_reads"]
-    short_reads_1 = snakemake.config["short_reads_1"]
-    short_reads_2 = snakemake.config["short_reads_2"]
-    long_read_type = snakemake.config["long_read_type"][0]
+    long_reads = snakemake.params.long_reads
+    short_reads_1 = snakemake.params.short_reads_1
+    short_reads_2 = snakemake.params.short_reads_2
+    long_read_type = snakemake.params.long_read_type
     input_fasta = snakemake.input.input_fasta
     tmpdir = snakemake.params.tmpdir
     threads = snakemake.threads

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -43,7 +43,7 @@ from glob import glob
 from snakemake import utils
 from snakemake.io import load_configfile
 from ruamel.yaml import YAML  # used for yaml reading with comments
-from aviary import LONG_READ_TYPES
+from aviary import LONG_READ_TYPES, COVERAGE_JOB_STRATEGIES, COVERAGE_JOB_CUTOFF
 
 BATCH_HEADER=['sample', 'short_reads_1', 'short_reads_2', 'long_reads', 'long_read_type', 'assembly', 'coassemble']
 
@@ -116,6 +116,23 @@ class Processor:
         try:
             self.min_contig_size = args.min_contig_size
             self.min_bin_size = args.min_bin_size
+
+            if args.coverage_job_strategy == COVERAGE_JOB_STRATEGIES[0]:
+                num_samples = 0
+                if args.pe1 != "none":
+                    num_samples += len(args.pe1)
+                if args.interleaved != "none":
+                    num_samples += len(args.interleaved)
+                if args.longreads != "none":
+                    num_samples += len(args.longreads)
+
+                self.coverage_split = num_samples >= COVERAGE_JOB_CUTOFF
+            elif args.coverage_job_strategy == COVERAGE_JOB_STRATEGIES[1]:
+                self.coverage_split = True
+            else:
+                self.coverage_split = False
+
+            self.coverage_samples_per_job = args.coverage_samples_per_job
             self.semibin_model = args.semibin_model
             self.refinery_max_iterations = args.refinery_max_iterations
             self.refinery_max_retries = args.refinery_max_retries
@@ -156,6 +173,8 @@ class Processor:
         except AttributeError:
             self.min_contig_size = 1500
             self.min_bin_size = 200000
+            self.coverage_split = False
+            self.coverage_samples_per_job = 5
             self.semibin_model = 'global'
             self.refinery_max_iterations = 5
             self.refinery_max_retries = 3
@@ -403,6 +422,8 @@ class Processor:
         conf["skip_singlem"] = self.skip_singlem
         conf["binning_only"] = self.binning_only
         conf["semibin_model"] = self.semibin_model
+        conf["coverage_split"] = self.coverage_split
+        conf["coverage_samples_per_split"] = self.coverage_samples_per_job
         conf["refinery_max_iterations"] = self.refinery_max_iterations
         conf["refinery_max_retries"] = self.refinery_max_retries
         conf["max_threads"] = int(self.threads)

--- a/aviary/modules/template_config.yaml
+++ b/aviary/modules/template_config.yaml
@@ -22,6 +22,10 @@ max_memory:
     250
 genome_size:
     5000000
+coverage_split:
+    False
+coverage_samples_per_split:
+    5
 reference_filter:
     none
 strain_analysis:


### PR DESCRIPTION
- [x] Move hardcoded paths to variables
- [x] Add split/gather coverage rule alternative (split into groups of n samples with long-reads last)
- [x] Add `--coverage-job-strategy` arg with `default` (when >=10 samples), `never`, `always` as options
- [x] Add `--coverage-samples-per-job` arg with default of 5
- [x] Test short-read
- [x] Test short+long
- [x] Test long-read
- [x] Test real world