### PR TITLE
Cluster improvements

### DIFF
--- a/aviary/modules/annotation/annotation.smk
+++ b/aviary/modules/annotation/annotation.smk
@@ -159,9 +159,9 @@ rule checkm2:
         mag_extension = config['mag_extension'],
         checkm2_db_path = config["checkm2_db_folder"]
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 16)
     resources:
-        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 64*1024*attempt),
         runtime = lambda wildcards, attempt: 8*60*attempt,
     log:
         'logs/checkm2.log'

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -179,9 +179,9 @@ rule vamb:
         min_bin_size = config["min_bin_size"],
         min_contig_size = config["min_contig_size"],
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
-        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 32*1024*attempt),
         runtime = lambda wildcards, attempt: 48*60*attempt,
     output:
         "data/vamb_bins/done"
@@ -240,7 +240,7 @@ rule metabuli_taxonomy:
     output:
         "data/metabuli_taxonomy/done"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         mem_gb = lambda wildcards, attempt: min(int(config["max_memory"]), 128*attempt),
@@ -289,9 +289,9 @@ rule taxvamb:
         min_contig_size = config["min_contig_size"],
         gpu_flag = "--cuda" if config["request_gpu"] else "",
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
-        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 32*1024*attempt),
         runtime = lambda wildcards, attempt: 48*60*attempt,
         gpus = 1 if config["request_gpu"] else 0
     output:
@@ -322,9 +322,9 @@ rule metabat2:
     conda:
         "envs/metabat2.yaml"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
-        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 32*1024*attempt),
         runtime = lambda wildcards, attempt: 12*60*attempt,
     log:
         "logs/metabat2.log"
@@ -353,7 +353,7 @@ rule metabat_spec:
     benchmark:
         "benchmarks/metabat_spec.benchmark.txt"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60*attempt,
@@ -379,7 +379,7 @@ rule metabat_sspec:
     benchmark:
         "benchmarks/metabat_sspec.benchmark.txt"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60*attempt,
@@ -405,7 +405,7 @@ rule metabat_sens:
     benchmark:
         "benchmarks/metabat_sens.benchmark.txt"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60*attempt,
@@ -431,7 +431,7 @@ rule metabat_ssens:
     benchmark:
         "benchmarks/metabat_ssens.benchmark.txt"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60*attempt,
@@ -457,7 +457,7 @@ rule rosella:
     conda:
         "envs/rosella.yaml"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60*attempt,
@@ -493,7 +493,7 @@ rule semibin:
     output:
         done = "data/semibin_bins/done"
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 24)
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 24*60 + 48*60*(attempt-1),
@@ -774,9 +774,9 @@ rule das_tool:
         vamb_done = [] if "vamb" in config["skip_binners"] else "data/vamb_bins/done",
         taxvamb_done = [] if "taxvamb" in config["skip_binners"] else "data/taxvamb_bins/done",
     threads:
-        config["max_threads"]
+        min(config["max_threads"], 10)
     resources:
-        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 512*1024*attempt),
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 128*1024*attempt),
         runtime = lambda wildcards, attempt: 12*60*attempt,
     output:
         touch("data/das_tool_bins_pre_refine/done")

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -1,4 +1,4 @@
-localrules: vamb_jgi_filter, vamb_skip, convert_metabuli, amber_checkm_output, finalise_stats, recover_mags, recover_mags_no_singlem
+localrules: vamb_skip, amber_checkm_output, recover_mags, recover_mags_no_singlem
 
 ruleorder: dereplicate_and_get_abundances_paired > dereplicate_and_get_abundances_interleaved
 ruleorder: checkm_rosella > amber_checkm_output
@@ -152,9 +152,11 @@ rule vamb_jgi_filter:
         fasta = ancient(config["fasta"]),
         done = ancient("data/coverm.cov")
     output:
-        vamb_bams_done = "data/coverm.filt.cov"
-    threads:
-        config["max_threads"]
+        vamb_bams_done = "data/coverm.filt.cov""]
+    threads: 1
+    resources:
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 16*1024*attempt),
+        runtime = lambda wildcards, attempt: 24*60*attempt,
     params:
         min_contig_size = config['min_contig_size']
     run:
@@ -265,8 +267,10 @@ rule convert_metabuli:
         filt_cov = ancient("data/coverm.filt.cov")
     output:
         "data/metabuli_taxonomy/taxonomy.tsv"
-    threads:
-        config["max_threads"]
+    threads: 1
+    resources:
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 16*1024*attempt),
+        runtime = lambda wildcards, attempt: 24*60*attempt,
     params:
         report = "data/metabuli_taxonomy/tax_report.tsv",
         classifications = "data/metabuli_taxonomy/tax_classifications.tsv",
@@ -846,6 +850,10 @@ rule finalise_stats:
     output:
         bin_stats = "bins/bin_info.tsv",
         checkm_minimal = "bins/checkm_minimal.tsv"
+    threads: 1
+    resources:
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 16*1024*attempt),
+        runtime = lambda wildcards, attempt: 24*60*attempt,
     script:
         "scripts/finalise_stats.py"
 

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -152,7 +152,7 @@ rule vamb_jgi_filter:
         fasta = ancient(config["fasta"]),
         done = ancient("data/coverm.cov")
     output:
-        vamb_bams_done = "data/coverm.filt.cov""]
+        vamb_bams_done = "data/coverm.filt.cov"
     threads: 1
     resources:
         mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 16*1024*attempt),

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -65,6 +65,12 @@ jobs: 10000
 cluster-cancel: qdel
 ```
 
+Job resources were set based on [empirical data from 1,000 Aviary runs](https://github.com/rhysnewell/aviary/pull/270).
+The number of CPUs was set based on the average mean load, to the nearest multiple of 8.
+The number of CPUs for binners was standardized to 24, since this was the most common usage pattern.
+Maximum memory was set based on the nearest power of 2, rounding up from the maximum RSS memory.
+These resources can be restricted by setting `--max_memory` and `--max_threads` in Aviary.
+
 ## Expected output
 
 Aviary will produce a variety of different outputs depending on the parameters provided. The following is a list of the expected outputs from the different subcommands.


### PR DESCRIPTION
- [x] More rules as cluster submission
- [x] Revisit resources

Benchmarks from 1000 coassemblies.
- cpu_time/h in hours
- max_rss/max_vms in GB
- mean_load divided by 100 (so roughly the average # of CPUs in use)

```bash
┌───────────────────────────────┬───────────┬───────┬────────┬───────┐
│ benchmark                     ┆ metric    ┆ min   ┆ median ┆ max   │
│ ---                           ┆ ---       ┆ ---   ┆ ---    ┆ ---   │
│ str                           ┆ str       ┆ f64   ┆ f64    ┆ f64   │
╞═══════════════════════════════╪═══════════╪═══════╪════════╪═══════╡
│ checkm2.benchmark.txt         ┆ cpu_time  ┆ 0.0   ┆ 1.3    ┆ 4.2   │
│ checkm2.benchmark.txt         ┆ h         ┆ 0.0   ┆ 0.1    ┆ 0.3   │
│ checkm2.benchmark.txt         ┆ max_rss   ┆ 5.1   ┆ 14.7   ┆ 19.1  │
│ checkm2.benchmark.txt         ┆ max_vms   ┆ 92.1  ┆ 101.6  ┆ 486.4 │
│ checkm2.benchmark.txt         ┆ mean_load ┆ 0.1   ┆ 13.1   ┆ 19.7  │
│ das_tool.benchmark.txt        ┆ cpu_time  ┆ 0.0   ┆ 1.2    ┆ 4.8   │
│ das_tool.benchmark.txt        ┆ h         ┆ 0.0   ┆ 0.4    ┆ 2.5   │
│ das_tool.benchmark.txt        ┆ max_rss   ┆ 0.3   ┆ 7.0    ┆ 134.1 │
│ das_tool.benchmark.txt        ┆ max_vms   ┆ 7.4   ┆ 33.3   ┆ 215.4 │
│ das_tool.benchmark.txt        ┆ mean_load ┆ 0.0   ┆ 2.4    ┆ 5.9   │
│ metabat_2.benchmark.txt       ┆ cpu_time  ┆ 0.0   ┆ 1.3    ┆ 22.1  │
│ metabat_2.benchmark.txt       ┆ h         ┆ 0.0   ┆ 0.1    ┆ 0.8   │
│ metabat_2.benchmark.txt       ┆ max_rss   ┆ 0.7   ┆ 3.8    ┆ 16.4  │
│ metabat_2.benchmark.txt       ┆ max_vms   ┆ 0.9   ┆ 4.1    ┆ 16.5  │
│ metabat_2.benchmark.txt       ┆ mean_load ┆ 6.3   ┆ 24.5   ┆ 29.1  │
│ metabat_sens.benchmark.txt    ┆ cpu_time  ┆ 0.0   ┆ 2.0    ┆ 46.9  │
│ metabat_sens.benchmark.txt    ┆ h         ┆ 0.0   ┆ 0.1    ┆ 2.2   │
│ metabat_sens.benchmark.txt    ┆ max_rss   ┆ 0.1   ┆ 3.9    ┆ 88.6  │
│ metabat_sens.benchmark.txt    ┆ max_vms   ┆ 2.1   ┆ 6.5    ┆ 105.8 │
│ metabat_sens.benchmark.txt    ┆ mean_load ┆ 0.3   ┆ 22.5   ┆ 31.2  │
│ metabat_spec.benchmark.txt    ┆ cpu_time  ┆ 0.0   ┆ 1.9    ┆ 42.3  │
│ metabat_spec.benchmark.txt    ┆ h         ┆ 0.0   ┆ 0.1    ┆ 2.0   │
│ metabat_spec.benchmark.txt    ┆ max_rss   ┆ 0.1   ┆ 3.6    ┆ 85.3  │
│ metabat_spec.benchmark.txt    ┆ max_vms   ┆ 2.2   ┆ 6.1    ┆ 103.9 │
│ metabat_spec.benchmark.txt    ┆ mean_load ┆ 0.4   ┆ 22.5   ┆ 30.8  │
│ metabat_ssens.benchmark.txt   ┆ cpu_time  ┆ 0.0   ┆ 2.0    ┆ 42.6  │
│ metabat_ssens.benchmark.txt   ┆ h         ┆ 0.0   ┆ 0.1    ┆ 1.9   │
│ metabat_ssens.benchmark.txt   ┆ max_rss   ┆ 0.1   ┆ 4.0    ┆ 88.6  │
│ metabat_ssens.benchmark.txt   ┆ max_vms   ┆ 2.1   ┆ 6.6    ┆ 106.0 │
│ metabat_ssens.benchmark.txt   ┆ mean_load ┆ 0.4   ┆ 22.5   ┆ 30.9  │
│ metabat_sspec.benchmark.txt   ┆ cpu_time  ┆ 0.0   ┆ 1.5    ┆ 36.0  │
│ metabat_sspec.benchmark.txt   ┆ h         ┆ 0.0   ┆ 0.1    ┆ 1.4   │
│ metabat_sspec.benchmark.txt   ┆ max_rss   ┆ 0.1   ┆ 3.5    ┆ 107.3 │
│ metabat_sspec.benchmark.txt   ┆ max_vms   ┆ 2.1   ┆ 5.9    ┆ 147.8 │
│ metabat_sspec.benchmark.txt   ┆ mean_load ┆ 0.3   ┆ 22.8   ┆ 28.5  │
│ metabuli.benchmark.txt        ┆ cpu_time  ┆ 0.1   ┆ 0.9    ┆ 3.9   │
│ metabuli.benchmark.txt        ┆ h         ┆ 0.0   ┆ 0.0    ┆ 0.3   │
│ metabuli.benchmark.txt        ┆ max_rss   ┆ 18.2  ┆ 80.7   ┆ 127.6 │
│ metabuli.benchmark.txt        ┆ max_vms   ┆ 126.3 ┆ 130.7  ┆ 130.7 │
│ metabuli.benchmark.txt        ┆ mean_load ┆ 5.6   ┆ 17.3   ┆ 24.6  │
│ refine_dastool.benchmark.txt  ┆ cpu_time  ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_dastool.benchmark.txt  ┆ h         ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_dastool.benchmark.txt  ┆ max_rss   ┆ 0.1   ┆ 0.1    ┆ 0.1   │
│ refine_dastool.benchmark.txt  ┆ max_vms   ┆ 4.2   ┆ 4.2    ┆ 4.2   │
│ refine_dastool.benchmark.txt  ┆ mean_load ┆ 0.0   ┆ 0.1    ┆ 1.2   │
│ refine_metabat2.benchmark.txt ┆ cpu_time  ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_metabat2.benchmark.txt ┆ h         ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_metabat2.benchmark.txt ┆ max_rss   ┆ 0.0   ┆ 0.1    ┆ 0.1   │
│ refine_metabat2.benchmark.txt ┆ max_vms   ┆ 4.2   ┆ 4.2    ┆ 4.2   │
│ refine_metabat2.benchmark.txt ┆ mean_load ┆ 0.0   ┆ 0.2    ┆ 2.0   │
│ refine_rosella.benchmark.txt  ┆ cpu_time  ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_rosella.benchmark.txt  ┆ h         ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_rosella.benchmark.txt  ┆ max_rss   ┆ 0.0   ┆ 0.1    ┆ 0.1   │
│ refine_rosella.benchmark.txt  ┆ max_vms   ┆ 4.2   ┆ 4.2    ┆ 4.2   │
│ refine_rosella.benchmark.txt  ┆ mean_load ┆ 0.0   ┆ 0.4    ┆ 1.4   │
│ refine_semibin.benchmark.txt  ┆ cpu_time  ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_semibin.benchmark.txt  ┆ h         ┆ 0.0   ┆ 0.0    ┆ 0.0   │
│ refine_semibin.benchmark.txt  ┆ max_rss   ┆ 0.1   ┆ 0.1    ┆ 0.1   │
│ refine_semibin.benchmark.txt  ┆ max_vms   ┆ 4.2   ┆ 4.2    ┆ 4.2   │
│ refine_semibin.benchmark.txt  ┆ mean_load ┆ 0.0   ┆ 0.1    ┆ 0.5   │
│ rosella.benchmark.txt         ┆ cpu_time  ┆ 0.0   ┆ 0.2    ┆ 92.1  │
│ rosella.benchmark.txt         ┆ h         ┆ 0.0   ┆ 0.1    ┆ 5.4   │
│ rosella.benchmark.txt         ┆ max_rss   ┆ 1.1   ┆ 58.0   ┆ 134.8 │
│ rosella.benchmark.txt         ┆ max_vms   ┆ 3.4   ┆ 136.1  ┆ 302.4 │
│ rosella.benchmark.txt         ┆ mean_load ┆ 0.3   ┆ 0.9    ┆ 30.0  │
│ semibin.benchmark.txt         ┆ cpu_time  ┆ 2.1   ┆ 9.5    ┆ 16.6  │
│ semibin.benchmark.txt         ┆ h         ┆ 0.1   ┆ 0.6    ┆ 2.3   │
│ semibin.benchmark.txt         ┆ max_rss   ┆ 17.4  ┆ 69.8   ┆ 266.5 │
│ semibin.benchmark.txt         ┆ max_vms   ┆ 180.8 ┆ 536.8  ┆ 737.5 │
│ semibin.benchmark.txt         ┆ mean_load ┆ 4.9   ┆ 16.0   ┆ 22.8  │
│ taxvamb.benchmark.txt         ┆ cpu_time  ┆ 0.0   ┆ 5.9    ┆ 26.2  │
│ taxvamb.benchmark.txt         ┆ h         ┆ 0.0   ┆ 1.0    ┆ 4.3   │
│ taxvamb.benchmark.txt         ┆ max_rss   ┆ 0.7   ┆ 16.5   ┆ 31.0  │
│ taxvamb.benchmark.txt         ┆ max_vms   ┆ 17.9  ┆ 152.5  ┆ 189.6 │
│ taxvamb.benchmark.txt         ┆ mean_load ┆ 1.9   ┆ 5.6    ┆ 13.0  │
│ vamb.benchmark.txt            ┆ cpu_time  ┆ 5.2   ┆ 92.9   ┆ 457.7 │
│ vamb.benchmark.txt            ┆ h         ┆ 0.2   ┆ 3.0    ┆ 14.8  │
│ vamb.benchmark.txt            ┆ max_rss   ┆ 0.7   ┆ 1.4    ┆ 2.1   │
│ vamb.benchmark.txt            ┆ max_vms   ┆ 19.4  ┆ 20.0   ┆ 20.7  │
│ vamb.benchmark.txt            ┆ mean_load ┆ 24.3  ┆ 30.7   ┆ 31.5  │
└───────────────────────────────┴───────────┴───────┴────────┴───────┘
```