### PR TITLE
Update singlem version to v0.19.0 in singlem_env.yaml for GTDB_r226

### DIFF
--- a/aviary/envs/singlem.yaml
+++ b/aviary/envs/singlem.yaml
@@ -5,6 +5,6 @@ channels:
 dependencies:
   - pip
   - python
-  - singlem >= 0.16.0
+  - singlem >= 0.19.0
   - pip:
       - bird-tool-utils


### PR DESCRIPTION
Was unable to run singlem using the r226 gtdb-tk metapackage (S5.4.0.GTDB_r226.metapackage_20250331.smpkg.zb) due to requiring zenodo-backpack v5.4.0 (up from v4.3.0).

Looks like others were having a similar issue with v0.18.3 on r226 https://github.com/wwood/singlem/issues/220.

Found that I could fix the issue by updating the singlem version dependency in singlm_env.yaml to v0.19.0.

I'm kinda new to this so might not be the best/correct fix, just thought it might help anyone else having the same problem.