### PR TITLE
Add Quickbin binner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,5 @@
 When adding new binning tools:
-1. When running a specific test, use `pixi run run-a-test -- test_name`, where `test_name` is the name of the test function to run (it is specified as the argument for pytest's `-k`). This allows for quick iteration on a specific test without running the full test suite.
+1. When running a specific test, use `pixi run run-a-test test_name`, where `test_name` is the name of the test function to run (it is specified as the argument for pytest's `-k`). This allows for quick iteration on a specific test without running the full test suite.
 2. To test for changes more broadly (but still relatively quickly), use `pixi run run-quick-tests`
 3. Add at least one test to test/test_integration.py which actually runs the tool being tested.
 4. Add at least one test to test/test_recovery.py which makes sure that the intermediate config file is accurately generated.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+When adding new binning tools:
+1. When running a specific test, use `pixi run run-a-test -- test_name`, where `test_name` is the name of the test function to run (it is specified as the argument for pytest's `-k`). This allows for quick iteration on a specific test without running the full test suite.
+2. To test for changes more broadly (but still relatively quickly), use `pixi run run-quick-tests`
+3. Add at least one test to test/test_integration.py which actually runs the tool being tested.
+4. Add at least one test to test/test_recovery.py which makes sure that the intermediate config file is accurately generated.
+5. Update the documentation in docs/binning_tools.md to include usage instructions and examples for the new tool. 
+6. Update docs/citations.md to include any relevant citations for the new tool.

--- a/aviary/aviary.py
+++ b/aviary/aviary.py
@@ -625,23 +625,23 @@ def main():
     binning_group.add_argument(
         '--extra-binners', '--extra_binners', '--extra-binner', '--extra_binner',
         help='Optional list of extra binning algorithms to run. Can be any combination of: \n'
-             'maxbin, maxbin2, concoct, comebin, taxvamb \n'
+             'maxbin, maxbin2, concoct, comebin, taxvamb, quickbin \n'
              'These binners are skipped by default as they can have long runtimes \n'
              'N.B. specifying "maxbin" and "maxbin2" are equivalent \n'
              'N.B. specifying "taxvamb" will also run metabuli for contig taxonomic assignment \n',
         dest='extra_binners',
         nargs='*',
-        choices=["maxbin", "maxbin2", "concoct", "comebin", "taxvamb"]
+        choices=["maxbin", "maxbin2", "concoct", "comebin", "taxvamb", "quickbin"]
     )
 
     binning_group.add_argument(
         '--skip-binners', '--skip_binners', '--skip_binner', '--skip-binner',
         help='Optional list of binning algorithms to skip. Can be any combination of: \n'
-             'rosella, semibin, metabat1, metabat2, metabat, vamb \n'
+             'rosella, semibin, metabat1, metabat2, metabat, vamb, quickbin \n'
              'N.B. specifying "metabat" will skip both MetaBAT1 and MetaBAT2. \n',
         dest='skip_binners',
         nargs='*',
-        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb"]
+        choices=["rosella", "semibin", "metabat1", "metabat2", "metabat", "vamb", "quickbin"]
     )
 
     binning_group.add_argument(

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -687,7 +687,7 @@ rule quickbin:
     input:
         large_contigs_done = "data/done/filter_contigs_by_size.done",
         fasta = "data/large_contigs.fasta",
-        coverage = ancient("data/coverm.cov")
+        bams_indexed = ancient("data/binning_bams/done")
     output:
         done = "data/quickbin_bins/done"
     threads:
@@ -706,8 +706,9 @@ rule quickbin:
     shell:
         "rm -rf data/quickbin_bins/; " + \
         "mkdir -p data/quickbin_bins && " + \
-        pixi_run + " -e bbmap quickbin.sh in={input.fasta} out=data/quickbin_bins/quickbin_bin%.fna cov={input.coverage} "
-        "mincontig={params.min_contig_size} mincluster={params.min_bin_size} {params.max_samples}threads={threads} > {resources.log_path} 2>&1 "
+        pixi_run + " -e bbmap quickbin.sh in={input.fasta} out=data/quickbin_bins/quickbin_bin%.fna "
+        "mincontig={params.min_contig_size} mincluster={params.min_bin_size} {params.max_samples}threads={threads} "
+        "data/binning_bams/*.bam > {resources.log_path} 2>&1 "
         "&& touch {output[0]} {params.touch}"
 
 

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -622,7 +622,7 @@ rule semibin:
     input:
         large_contigs_done = "data/done/filter_contigs_by_size.done",
         fasta = "data/large_contigs.fasta",
-        coverage = ancient("data/coverm.cov")
+        bams_indexed = ancient("data/binning_bams/done")
     params:
         # Can't use premade model with multiple samples, so disregard if provided
         semibin_model = f"--environment {config['semibin_model']} " if get_num_samples() == 1 else "",
@@ -662,7 +662,7 @@ rule comebin:
     input:
         large_contigs_done = "data/done/filter_contigs_by_size.done",
         fasta = "data/large_contigs.fasta",
-        coverage = ancient("data/coverm.cov")
+        bams_indexed = ancient("data/binning_bams/done")
     output:
         done = "data/comebin_bins/done"
     threads:

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -622,7 +622,7 @@ rule semibin:
     input:
         large_contigs_done = "data/done/filter_contigs_by_size.done",
         fasta = "data/large_contigs.fasta",
-        bams_indexed = ancient("data/binning_bams/done")
+        coverage = ancient("data/coverm.cov")
     params:
         # Can't use premade model with multiple samples, so disregard if provided
         semibin_model = f"--environment {config['semibin_model']} " if get_num_samples() == 1 else "",
@@ -662,7 +662,7 @@ rule comebin:
     input:
         large_contigs_done = "data/done/filter_contigs_by_size.done",
         fasta = "data/large_contigs.fasta",
-        bams_indexed = ancient("data/binning_bams/done")
+        coverage = ancient("data/coverm.cov")
     output:
         done = "data/comebin_bins/done"
     threads:
@@ -682,6 +682,33 @@ rule comebin:
         "rm -rf data/comebin_bins/; " + \
         pixi_run + " -e {params.pixi_env} run_comebin.sh -a {input.fasta} -p data/binning_bams -t {threads} -o data/comebin_bins > {resources.log_path} 2>&1 "
         "&& touch {output[0]} {params.really_done} {params.touch}"
+
+rule quickbin:
+    input:
+        large_contigs_done = "data/done/filter_contigs_by_size.done",
+        fasta = "data/large_contigs.fasta",
+        coverage = ancient("data/coverm.cov")
+    output:
+        done = "data/quickbin_bins/done"
+    threads:
+        config["max_threads"]
+    params:
+        min_contig_size = config["min_contig_size"],
+        min_bin_size = config["min_bin_size"],
+        max_samples = f"maxsamples={config['coverage_samples_per_split']} " if config["coverage_split"] else "",
+        touch = "" if config["strict"] else "|| (mkdir -p data/quickbin_bins && touch data/quickbin_bins/done)",
+    resources:
+        mem_mb = lambda wildcards, attempt: min(int(config["max_memory"])*1024, 512*1024*attempt),
+        runtime = lambda wildcards, attempt: 24*60 + 24*60*attempt,
+        log_path = lambda wildcards, attempt: setup_log(f"{logs_dir}/quickbin", attempt),
+    benchmark:
+        "benchmarks/quickbin.benchmark.txt"
+    shell:
+        "rm -rf data/quickbin_bins/; " + \
+        "mkdir -p data/quickbin_bins && " + \
+        pixi_run + " -e bbmap quickbin.sh in={input.fasta} out=data/quickbin_bins/quickbin_bin%.fna cov={input.coverage} "
+        "mincontig={params.min_contig_size} mincluster={params.min_bin_size} {params.max_samples}threads={threads} > {resources.log_path} 2>&1 "
+        "&& touch {output[0]} {params.touch}"
 
 
 rule checkm_rosella:
@@ -959,6 +986,7 @@ rule das_tool:
         rosella_done = [] if "rosella" in config["skip_binners"] else "data/rosella_refined/done",
         semibin_done = [] if "semibin" in config["skip_binners"] else "data/semibin_refined/done",
         comebin_done = [] if "comebin" in config["skip_binners"] else "data/comebin_bins/done",
+        quickbin_done = [] if "quickbin" in config["skip_binners"] else "data/quickbin_bins/done",
         vamb_done = [] if "vamb" in config["skip_binners"] else "data/vamb_bins/done",
         taxvamb_done = [] if "taxvamb" in config["skip_binners"] else "data/taxvamb_bins/done",
     threads:

--- a/aviary/modules/binning/binning.smk
+++ b/aviary/modules/binning/binning.smk
@@ -706,10 +706,11 @@ rule quickbin:
     shell:
         "rm -rf data/quickbin_bins/; " + \
         "mkdir -p data/quickbin_bins && " + \
-        pixi_run + " -e bbmap quickbin.sh in={input.fasta} out=data/quickbin_bins/quickbin_bin%.fna "
-        "mincontig={params.min_contig_size} mincluster={params.min_bin_size} {params.max_samples}threads={threads} "
+        pixi_run + " -e bbmap quickbin.sh in={input.fasta} out=data/quickbin_bins "
+        "mincontig={params.min_contig_size} mincluster={params.min_bin_size} threads={threads} "
         "data/binning_bams/*.bam > {resources.log_path} 2>&1 "
-        "&& touch {output[0]} {params.touch}"
+        "&& for f in data/quickbin_bins/*.fa; do [ -e \"$f\" ] && mv \"$f\" \"${{f%.fa}}.fna\"; done; "
+        "touch {output[0]} {params.touch}"
 
 
 rule checkm_rosella:

--- a/aviary/modules/binning/scripts/das_tool.py
+++ b/aviary/modules/binning/scripts/das_tool.py
@@ -33,6 +33,7 @@ if __name__ == '__main__':
         ('vamb', 'fna'),
         ('comebin', 'fa'),
         ('taxvamb', 'fna'),
+        ('quickbin', 'fna'),
     ]
     refined_binners_to_use = [
         ('rosella', 'fna'),

--- a/aviary/modules/processor.py
+++ b/aviary/modules/processor.py
@@ -139,7 +139,7 @@ class Processor:
                 self.skip_singlem = True
             self.binning_only = args.binning_only
 
-            self.skip_binners = ["maxbin2", "concoct", "comebin", "taxvamb"]
+            self.skip_binners = ["maxbin2", "concoct", "comebin", "taxvamb", "quickbin"]
             if args.extra_binners:
                 for binner in args.extra_binners:
                     binner = binner.lower()   
@@ -151,6 +151,8 @@ class Processor:
                         self.skip_binners.remove("comebin")
                     elif binner == "taxvamb":
                         self.skip_binners.remove("taxvamb")
+                    elif binner == "quickbin":
+                        self.skip_binners.remove("quickbin")
                     else:
                         logging.warning(f"Unknown extra binner {binner} specified. Skipping...")
 

--- a/aviary/pixi.lock
+++ b/aviary/pixi.lock
@@ -4,12 +4,14 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.14-hb9d3cd8_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/bbmap-39.26-he5f24ec_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/bbmap-39.52-he5f24ec_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.5-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2025.4.26-hbd8a1cb_0.conda
@@ -25,15 +27,15 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/giflib-5.2.2-hd590300_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.13-h59595ed_1003.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/harfbuzz-11.2.1-h3beb420_0.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.22-h566b1c6_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.23-h566b1c6_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/icu-75.1-he02047a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.1-h166bdaf_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.21.3-h659f571_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.17-h717163a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.0.0-h0aef613_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-hb8b1518_5.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.14.1-h332b0f4_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.24-h86f0d12_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.22-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h7949ede_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-hd590300_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.7.0-h5888daf_0.conda
@@ -47,23 +49,23 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h4ce23a2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.1.0-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.1-hb9d3cd8_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.64.0-h161d5f1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.67.0-had1ee68_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.47-h943b412_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libssh2-1.11.1-hcf80075_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.1.0-h8f9b012_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-ng-15.1.0-h4852527_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hf01ce69_5.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.0-hc4654cb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.38.1-h0b41bf4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.5.0-h851e524_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-h2d0b736_3.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openjdk-23.0.2-h53dfc1b_2.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.5.0-h7b32b05_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.0-h26f9b46_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.45-hc749103_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.2-h29eaf8c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-hb9d3cd8_1002.conda
-      - conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.22-h96c455f_0.tar.bz2
+      - conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.23-h96c455f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-he73a12e_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.12-h4f16b4b_0.conda
@@ -81,6 +83,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -208,6 +212,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -240,6 +246,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -412,6 +420,7 @@ environments:
     - url: https://conda.anaconda.org/pytorch/
     options:
       channel-priority: disabled
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -598,6 +607,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -663,6 +674,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -730,6 +743,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -940,6 +955,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1146,6 +1163,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1369,6 +1388,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1437,6 +1458,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1509,6 +1532,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1593,6 +1618,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1624,6 +1651,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1674,6 +1703,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1834,6 +1865,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1876,6 +1909,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1915,6 +1950,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1932,6 +1969,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -1974,6 +2013,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2105,6 +2146,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2289,6 +2332,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -2458,6 +2503,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -2586,6 +2633,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2626,6 +2675,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2808,6 +2859,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -2972,6 +3025,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3100,6 +3155,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -3245,6 +3302,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/bioconda/linux-64/seqkit-2.10.0-h9ee0642_0.tar.bz2
@@ -3252,6 +3311,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3505,6 +3566,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
@@ -3545,6 +3608,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -3638,6 +3703,8 @@ environments:
     - url: https://conda.anaconda.org/bioconda/
     - url: https://conda.anaconda.org/pytorch/
     - url: https://conda.anaconda.org/nvidia/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -3764,6 +3831,8 @@ environments:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
     - url: https://conda.anaconda.org/bioconda/
+    options:
+      pypi-prerelease-mode: if-necessary-or-explicit
     packages:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-3_kmp_llvm.conda
@@ -4662,17 +4731,17 @@ packages:
   - pkg:pypi/backports-zstd?source=hash-mapping
   size: 238087
   timestamp: 1765057663263
-- conda: https://conda.anaconda.org/bioconda/linux-64/bbmap-39.26-he5f24ec_0.tar.bz2
-  sha256: 35fb79201ff8ef4ecf8c5ada027de9bb52d86919b1f72a929ce48a0f931fb293
-  md5: 8725e8f069d35a4f2e71efaee72c76ad
+- conda: https://conda.anaconda.org/bioconda/linux-64/bbmap-39.52-he5f24ec_0.conda
+  sha256: d13a24a5fa4ae14944be45659b8bda9dba073f29c5aaec64aa37857f60986fc0
+  md5: e6eab94b6b57dbf9433e5433949c85e4
   depends:
   - bzip2 >=1.0.8,<2.0a0
   - libgcc >=13
   - openjdk >=11.0.1
-  - samtools >=1.21,<2.0a0
+  - samtools >=1.22.1,<2.0a0
   license: UC-LBL license (see package)
-  size: 14648766
-  timestamp: 1748307913364
+  size: 15870752
+  timestamp: 1763954174010
 - conda: https://conda.anaconda.org/conda-forge/linux-64/bc-1.07.1-h7f98852_0.tar.bz2
   sha256: c5e04d9408a0047bd87156b1853a4ac31cb3a5ccdc52374d89c72cbdabe95002
   md5: 9ff50d162aa3b1c861fa30105bea1932
@@ -8048,6 +8117,21 @@ packages:
   license_family: MIT
   size: 3240945
   timestamp: 1748687751804
+- conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.23-h566b1c6_0.conda
+  sha256: 71f16369db0a32da447e7f244f2e9db5db801335a0dbc9189adf0d0d673fb779
+  md5: 307124911d36a3d976cd76f350085ead
+  depends:
+  - bzip2 >=1.0.8,<2.0a0
+  - libcurl >=8.17.0,<9.0a0
+  - libdeflate >=1.22,<1.23.0a0
+  - libgcc >=13
+  - liblzma >=5.8.1,<6.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.6.0,<4.0a0
+  license: MIT
+  license_family: MIT
+  size: 1197549
+  timestamp: 1765902682113
 - conda: https://conda.anaconda.org/bioconda/linux-64/htslib-1.9-h244ad75_9.tar.bz2
   sha256: d4386c43322836508e78a375a7c44c1d0f35e65ffeba7d8f048b712c46fa4ecd
   md5: 8007a4b2f354481d744a38e00ac1cf9f
@@ -9773,6 +9857,22 @@ packages:
   purls: []
   size: 459417
   timestamp: 1765379027010
+- conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.18.0-h4e3cde8_0.conda
+  sha256: 5454709d9fb6e9c3dd6423bc284fa7835a7823bfa8323f6e8786cdd555101fab
+  md5: 0a5563efed19ca4461cf927419b6eb73
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - krb5 >=1.21.3,<1.22.0a0
+  - libgcc >=14
+  - libnghttp2 >=1.67.0,<2.0a0
+  - libssh2 >=1.11.1,<2.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - openssl >=3.5.4,<4.0a0
+  - zstd >=1.5.7,<1.6.0a0
+  license: curl
+  license_family: MIT
+  size: 462942
+  timestamp: 1767821743793
 - conda: https://conda.anaconda.org/conda-forge/linux-64/libcurl-8.8.0-hca28451_1.conda
   sha256: 6b5b64cdcdb643368ebe236de07eedee99b025bb95129bbe317c46e5bdc693f3
   md5: b8afb3e3cb3423cc445cf611ab95fdb0
@@ -18775,6 +18875,17 @@ packages:
   license: MIT
   size: 502181
   timestamp: 1748907824610
+- conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.23-h96c455f_0.conda
+  sha256: baf3fcf005aac25034ec33debc40946b618b72c9e1da5287b1d468317c0da570
+  md5: f5426f4f0024640896a5582a5e75f285
+  depends:
+  - htslib >=1.23,<1.24.0a0
+  - libgcc >=13
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  license: MIT
+  size: 488688
+  timestamp: 1765917481431
 - conda: https://conda.anaconda.org/bioconda/linux-64/samtools-1.9-h10a08f8_12.tar.bz2
   sha256: 06441e2e0208bf8cc2506c47152a0fbfd5487970e5cfceb9c2fee3bda535a8bc
   md5: a30f9567459497443fb98c5d46384769

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -22,6 +22,15 @@ pip = "*"
 postinstall = "pip install --no-build-isolation --no-deps --disable-pip-version-check -e .."
 update_deps = { cmd = "python ../admin/build_dep_defs_from_pixi.py", depends-on = ["postinstall"] }
 
+[tasks.run-a-test]
+args = ["test_name"]
+cmd = "pytest test --run-expensive -k {{ test_name }}"
+depends-on = ["postinstall"]
+
+[tasks.run-quick-tests]
+cmd = "pytest test"
+depends-on = ["postinstall"]
+
 [feature.dev.dependencies]
 pytest = "*"
 ipython = "*"

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -127,7 +127,7 @@ nanoplot = ">=1.44"
 quast = "==5.0.2"
 
 [feature.bbmap.dependencies]
-bbmap = ">=39.01"
+bbmap = ">=39.52"
 
 [feature.flye.dependencies]
 flye = ">=2.9"

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -19,7 +19,7 @@ pixi = "*"
 pip = "*"
 
 [tasks]
-postinstall = "pip install --no-build-isolation --no-deps --disable-pip-version-check -e .."
+postinstall = { cmd = "pip install --no-build-isolation --no-deps --disable-pip-version-check -e ..", cwd = "aviary" }
 update_deps = { cmd = "python ../admin/build_dep_defs_from_pixi.py", depends-on = ["postinstall"] }
 
 [tasks.run-a-test]

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -100,7 +100,7 @@ nanoplot = ">=1.44"
 quast = "==5.0.2"
 
 [feature.bbmap.dependencies]
-bbmap = "*"
+bbmap = ">=39.01"
 
 [feature.flye.dependencies]
 flye = ">=2.9"

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -30,6 +30,9 @@ depends-on = ["postinstall"]
 [tasks.run-a-test]
 args = ["test_name"]
 depends-on = [
+    # run postinstall in the dev environment
+    { task = "postinstall", environment = "dev" },
+    # then run the tests in the same env
     {task = "run-a-test-base", environment = "dev", args = [ "{{ test_name }}" ] }
 ]
 
@@ -40,6 +43,9 @@ depends-on = ["postinstall"]
 [tasks.run-quick-tests]
 args = ["test_name"]
 depends-on = [
+    # run postinstall in the dev environment
+    { task = "postinstall", environment = "dev" },
+    # then run the tests in the same env
     {task = "run-quick-tests-base", environment = "dev" }
 ]
 

--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -22,14 +22,26 @@ pip = "*"
 postinstall = { cmd = "pip install --no-build-isolation --no-deps --disable-pip-version-check -e ..", cwd = "aviary" }
 update_deps = { cmd = "python ../admin/build_dep_defs_from_pixi.py", depends-on = ["postinstall"] }
 
-[tasks.run-a-test]
+[tasks.run-a-test-base]
 args = ["test_name"]
 cmd = "pytest test --run-expensive -k {{ test_name }}"
 depends-on = ["postinstall"]
 
-[tasks.run-quick-tests]
+[tasks.run-a-test]
+args = ["test_name"]
+depends-on = [
+    {task = "run-a-test-base", environment = "dev", args = [ "{{ test_name }}" ] }
+]
+
+[tasks.run-quick-tests-base]
 cmd = "pytest test"
 depends-on = ["postinstall"]
+
+[tasks.run-quick-tests]
+args = ["test_name"]
+depends-on = [
+    {task = "run-quick-tests-base", environment = "dev" }
+]
 
 [feature.dev.dependencies]
 pytest = "*"

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -544,11 +544,6 @@ class Tests(unittest.TestCase):
         setup_output_dir(output_dir)
 
         cmd = (
-            f"GTDBTK_DATA_PATH=. "
-            f"CHECKM2DB=. "
-            f"EGGNOG_DATA_DIR=. "
-            f"METABULI_DB_PATH=. "
-            f"SINGLEM_METAPACKAGE_PATH=. "
             f"aviary recover "
             f"--assembly {data}/assembly.fasta "
             f"-o {output_dir}/aviary_out "

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -539,6 +539,34 @@ class Tests(unittest.TestCase):
 
         self.assertFalse(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
 
+    def test_short_read_recovery_quickbin(self):
+        output_dir = os.path.join("example", "test_short_read_recovery_quickbin")
+        setup_output_dir(output_dir)
+
+        cmd = (
+            f"aviary recover "
+            f"--assembly {data}/assembly.fasta "
+            f"-o {output_dir}/aviary_out "
+            f"-1 {data}/wgsim.1.fq.gz "
+            f"-2 {data}/wgsim.2.fq.gz "
+            f"--binning-only "
+            f"--skip-binners rosella semibin metabat vamb "
+            f"--extra-binners quickbin "
+            f"--skip-qc "
+            f"--refinery-max-iterations 0 "
+            f"-n 32 -t 32 "
+            f"--strict "
+        )
+        subprocess.run(cmd, shell=True, check=True)
+
+        bin_info_path = f"{output_dir}/aviary_out/bins/bin_info.tsv"
+        self.assertTrue(os.path.isfile(bin_info_path))
+        with open(bin_info_path) as f:
+            num_lines = sum(1 for _ in f)
+        self.assertTrue(num_lines > 2)
+
+        self.assertFalse(os.path.isfile(f"{output_dir}/aviary_out/data/final_contigs.fasta"))
+
     def test_short_read_recovery_no_bins(self):
         output_dir = os.path.join("example", "test_short_read_recovery_no_bins")
         setup_output_dir(output_dir)

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -544,6 +544,11 @@ class Tests(unittest.TestCase):
         setup_output_dir(output_dir)
 
         cmd = (
+            f"GTDBTK_DATA_PATH=. "
+            f"CHECKM2DB=. "
+            f"EGGNOG_DATA_DIR=. "
+            f"METABULI_DB_PATH=. "
+            f"SINGLEM_METAPACKAGE_PATH=. "
             f"aviary recover "
             f"--assembly {data}/assembly.fasta "
             f"-o {output_dir}/aviary_out "

--- a/test/test_recover.py
+++ b/test/test_recover.py
@@ -192,6 +192,27 @@ class Tests(unittest.TestCase):
             # Unnecessary
             self.assertTrue("complete_assembly_with_qc" not in output)
 
+    def test_recover_quickbin(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cmd = (
+                f"GTDBTK_DATA_PATH=. "
+                f"CHECKM2DB=. "
+                f"EGGNOG_DATA_DIR=. "
+                f"METABULI_DB_PATH=. "
+                f"SINGLEM_METAPACKAGE_PATH=. "
+                f"aviary recover "
+                f"--assembly {ASSEMBLY} "
+                f"-1 {FORWARD_READS} "
+                f"-2 {REVERSE_READS} "
+                f"--extra-binners quickbin "
+                f"--output {tmpdir}/test "
+                f"--dryrun --tmpdir {tmpdir} "
+                f"--snakemake-cmds \" --quiet\" "
+            )
+            output = extern.run(cmd)
+
+            self.assertTrue("quickbin" in output)
+
     def test_recover_no_singlem(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             cmd = (


### PR DESCRIPTION
Integration test for it passes, but not yet tested on any real data. Proper testing happening now.

I also added some AGENT stuff which will help adding new binners in future, and now this works:
```
pixi run run-a-test quickbin
```
which runs `pytest -k quickbin` including expensive ones.

One issue is the pixi.toml being in both base dir and aviary/ because e.g. the scripts directory needs to be relative to one of those paths only AFAICS. WDYT about removing the pixi.toml from the base dir, since it is required for deployment @AroneyS  ? Unless there is some other way.

Thanks, ben