### PR TITLE
Add checkm2 feature with activation environment configuration

### DIFF
--- a/aviary/pixi.toml
+++ b/aviary/pixi.toml
@@ -243,6 +243,9 @@ metabat2 = ">=2.15"
 [feature.checkm2.dependencies]
 checkm2 = ">=1.1.0"
 
+[feature.checkm2.activation]
+env = { PYTHONNOUSERSITE = "1" }
+
 [feature.coverm.dependencies]
 coverm = ">=0.6"
 galah = ">=0.3"


### PR DESCRIPTION
After the updating of all packages, numpy within requirements.txt increased to 2.4.1. When running the mock sample test say that i was running into the error "A module that was compiled using NumPy 1.x cannot be run in NumPy 2.4.1 as it may crash." Within checkm2. Tried to pin version <2.0 within checkm2 dependencies, however NumPy leakage was causing 2.4.1 still to be present after stating <2.0. Changed activation to PYTHONNOUSERSITE=1 to stop the env from overriding. Afterwards package ran normally. 